### PR TITLE
Add Tool Advisor to 编程辅助 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Agent Skills 作为一套基于文件系统的跨平台标准，可以灵活地�
 -   [nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)：面向 UI/UX 设计的 Skills 集合
 -   [OthmanAdi/planning-with-files](https://github.com/OthmanAdi/planning-with-files)：使用文件规划实现长期 Plan 效果的 Skill
 -   [hyf0/vue-skills](https://github.com/hyf0/vue-skills)：面向 Vue.js 开发的 Skills 集合
+-   [dragon1086/claude-skills](https://github.com/dragon1086/claude-skills)：分析提示词并推荐最佳工具、技能、代理和编排模式的 Skill
 
 ### 产品使用
 


### PR DESCRIPTION
## 概述

将 [Tool Advisor](https://github.com/dragon1086/claude-skills) 添加到 精选技能 → 编程辅助 部分。

**功能说明：**
- 分析自然语言提示词，推荐最佳工具、技能、代理和编排模式
- 为复杂的长时间任务建议 Harness 模式（Ralph、RIPER、Spec）
- 在缺少所需工具时提供安装建议
- 通过"快速操作"表格提供可直接复制粘贴的命令

**特性：**
- 6阶段分析流程
- 多语言 README 支持（EN、KO、JA、ZH、ES、PT、RU、FR、DE）
- 一行安装：`curl -fsSL https://raw.githubusercontent.com/dragon1086/claude-skills/main/install.sh | bash`

## 检查清单

- [x] 技能存在且可正常使用
- [x] 遵循列表格式
- [x] 添加到适当的部分（编程辅助）
- [x] 描述简洁明了