### PR TITLE
Add TweetClaw and repair stale documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ skillhub upgrade # 升级已安装的技能
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：操控 NotebookLM 
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
+-   [tweetclaw](https://github.com/Xquik-dev/tweetclaw)：X/Twitter 自动化插件，支持发推、回复、点赞、转推、关注、私信等 40+ 接口
 
 ### 其他类型
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -237,6 +237,7 @@ skillhub upgrade                  # Upgrade installed skills
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py): Control NotebookLM
 -   [n8n](https://github.com/czlonkowski/n8n-skills): Create n8n workflows
 -   [threejs](https://github.com/cloudai-x/threejs-skills): Assist with Three.js development
+-   [tweetclaw](https://github.com/Xquik-dev/tweetclaw): X/Twitter automation plugin - post, reply, like, retweet, follow, DM and more (40+ endpoints via Xquik)
 
 ### Other Types
 


### PR DESCRIPTION
## Summary

- Add TweetClaw to the Chinese, English, and Japanese Product Usage lists.
- Document the current OpenClaw install, API key, and tool allowlist commands.
- Add approval guidance and the required Xquik independence notice.
- Remove the stale tldraw Helper guide for a plugin deleted from this repository.
- Repair the malformed code-simplifier link and 2 broken Japanese guide links.

## Independent Repository Fix

The plugin guide still advertised `tldraw-helper` after commit `ec15e12` removed it. Its documentation link returned a missing repository path. This PR removes that stale 50-line section and restores 3 other broken documentation links.

## Validation

- `git diff --check upstream/main...HEAD`
- Rendered all 4 changed Markdown files with the repository's GFM parser.
- Verified every local link in the changed files resolves.
- Verified all added external links return HTTP 200.
- Matched all 3 commands against the current TweetClaw README.
- Confirmed the branch contains one signed commit on the current upstream base.

Prepared with AI assistance and reviewed by Burak Bayır.
