### PR TITLE
docs: 添加 openclaw-soul-forge 到精选技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ skillhub upgrade # 升级已安装的技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [openclaw-soul-forge](https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-soul-forge)：英文版龙虾灵魂锻造，为 OpenClaw Agent 创建完整人格，支持抽卡和定向锻造
 
 
 ## 安全警示


### PR DESCRIPTION
## Summary

- 在「其他类型」分类下添加 [openclaw-soul-forge](https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-soul-forge) 条目
- 英文版龙虾灵魂锻造，为 OpenClaw Agent 创建完整人格，支持抽卡和定向锻造
- ClawHub: https://clawhub.ai/eamanc-lab/openclaw-soul-forge