### PR TITLE
docs: 添加 openclaw-user-profiler 到精选技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ skillhub upgrade # 升级已安装的技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [openclaw-user-profiler](https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-user-profiler)：通过对话构建用户画像，并根据 42 种角色推荐匹配的 Claude Code Skills
 
 
 ## 安全警示


### PR DESCRIPTION
## Summary

- 在「其他类型」分类下添加 [openclaw-user-profiler](https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-user-profiler) 条目
- 通过对话构建用户画像（user.md），并根据 42 种角色推荐匹配的 Claude Code Skills
- ClawHub: https://clawhub.ai/eamanc-lab/openclaw-user-profiler