### PR TITLE
安全审查: 添加 CoWorker Protocol — Agent 间安全协作的协议层方案

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ skillhub upgrade # 升级已安装的技能
 
 如果使用 OpenClaw 这类具有高度自主权限的 Agent Harness，建议配合使用 [OpenClaw极简安全实践指南](https://github.com/slowmist/openclaw-security-practice-guide) ，通过系统提示词级别的安全约束，最大程度地降低潜在风险。
 
+如果需要在多个 Agent 之间安全协作，可以使用 [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker) 实现 Skill-as-API —— 其他 Agent 只能调用你的技能拿到结果，看不到你的代码、提示词和内部逻辑。支持 4 层信任分层与自动降级、技能可见性控制（隐藏的技能对方连存在都不知道）、异步委托、SKILL.md 兼容（`coworker wrap` 一键保护现有 Skill）以及 MCP 桥接（`coworker mcp serve` 让 Claude Code 直接调用）。
+
 ## 创建技能
 
 虽然可以通过技能商店直接安装他人创建的技能，但是为了提升技能的适配度和个性化，强烈建议根据需要自己动手创建技能，或者在其他人的基础上进行微调。


### PR DESCRIPTION
在安全审查章节添加 [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker)。

**为什么放在安全审查？**

现有的安全方案（slowmist-agent-security、OpenClaw 安全指南）解决的是"单个 Skill 是否安全"。
CoWorker 解决的是另一个问题："Agent 之间协作时，怎么保护 Skill 的实现不被泄露"。

**核心能力：**
- Skill-as-API：对方调用你的技能，只看到输入输出 schema，看不到代码和提示词
- 4 层信任分层 + 自动降级：协作完权限收回
- 技能可见性控制：隐藏的技能返回"未知技能"，不泄露存在性
- `coworker wrap ./my-skill/`：一键保护现有 SKILL.md
- `coworker mcp serve`：让 Claude Code 直接通过 MCP 调用
- 异步委托：对方不在线也能发任务

**安装：** `pip install agent-coworker`（零依赖）
**协议：** MIT 开源