### PR TITLE
添加 fabbo-ai-generator 技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ skillhub upgrade # 升级已安装的技能
 -   [op7418](https://github.com/op7418)：歸藏创作的高质量 PPT 制作、Youtube 分析技能
 -   [cclank](https://github.com/cclank/news-aggregator-skill)：自动抓取和总结指定领域的最新资讯
 -   [huangserva](https://github.com/huangserva/skill-prompt-generator)：生成和优化 AI 人像文生图提示词
+-   [fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator)：驱动 Playwright 浏览器在 [fabbo.ai](https://fabbo.ai) 上生成 AI 视频和图片，支持文生视频、图生视频、文生图、参考图生视频、图片编辑等模式，覆盖 Veo、Sora、Kling、Wan、Luma、Runway、Midjourney、Nano Banana 等模型
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
 


### PR DESCRIPTION
为「精选技能 → 内容创作」添加 [fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator)。

这是一个跨 Agent（Claude Code / Codex）的 SKILL.md 技能包，通过驱动真实 Playwright 浏览器会话，在 [fabbo.ai](https://fabbo.ai) 上生成 AI 视频和图片，覆盖 Veo、Sora、Kling、Wan、Luma、Runway、Midjourney、Nano Banana 等主流模型，支持文生视频、图生视频、文生图、参考图生视频、图片编辑等模式。