### PR TITLE
Add buyer-eval-skill to 精选技能 → 其他类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ skillhub upgrade # 升级已安装的技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill)：结构化 B2B 软件供应商评估，7 维度评分与证据追踪的评分卡，用于采购与自建/采购决策
 
 
 ## 安全审查


### PR DESCRIPTION
将 [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) 添加至 **精选技能 → 其他类型** 分类。

**功能简介**：结构化 B2B 软件供应商评估技能。按软件品类提出领域专家级问题，与供应商 AI 代理对话以验证尽调，从 7 个维度对供应商打分并保留证据追踪，最终输出可对比的评分卡，用于采购、RFP 评估与自建/采购决策。

**许可证**：MIT

**安装**：
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

放在 其他类型 分类，与 marketingskills、scientific-skills、office-hours 等通用工作场景技能并列。