### PR TITLE
Add x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ skillhub upgrade # 升级已安装的技能
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：操控 NotebookLM 
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
+-   [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)：Xquik 的 X/Twitter 数据 Skill，用于推文搜索、用户推文、粉丝导出、媒体下载、Webhooks、MCP 和确认后发推/回复
 
 ### 其他类型
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ gh skill publish                                 # 校验并发布技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 -   [skills-manage](https://github.com/iamzhihuix/skills-manage)：跨多种 Agent 管理本地 Skills
+-   [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)：X/Twitter 数据 Skill，支持搜索、用户推文、粉丝导出、媒体下载、Webhook 与确认后的发布操作
 
 ### 其他类型
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -237,6 +237,7 @@ skillhub upgrade                  # Upgrade installed skills
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py): Control NotebookLM
 -   [n8n](https://github.com/czlonkowski/n8n-skills): Create n8n workflows
 -   [threejs](https://github.com/cloudai-x/threejs-skills): Assist with Three.js development
+-   [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper): Xquik Skill for X/Twitter data workflows: tweet search, user tweets, follower export, media download, webhooks, MCP, and confirmation-gated posting or replies
 
 ### Other Types
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -266,6 +266,7 @@ gh skill publish                                 # Validate and publish a Skill
 -   [n8n](https://github.com/czlonkowski/n8n-skills): Create n8n workflows
 -   [threejs](https://github.com/cloudai-x/threejs-skills): Assist with Three.js development
 -   [skills-manage](https://github.com/iamzhihuix/skills-manage): Manage local Skills across multiple agent hosts
+-   [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper): Agent Skill for structured X/Twitter search, timelines, follower exports, media, webhooks, and confirmation-gated publishing
 
 ### Other Types
 


### PR DESCRIPTION
## Summary

Add `x-twitter-scraper` to the Product Usage section in the Chinese and English READMEs.

This is the Xquik Skill for X/Twitter data workflows: tweet search, user tweets, follower export, media download, webhooks, MCP, and confirmation-gated posting or replies.

## Checks

- Checked the repository for existing Xquik, TweetClaw, or x-twitter-scraper entries.
- Checked open and closed PRs/issues for duplicate x-twitter-scraper submissions.
- Verified the linked repository and Xquik docs return HTTP 200.
- Kept the change to 2 list entries only.
