### PR TITLE
添加 html-anything 到内容创作分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ skillhub upgrade # 升级已安装的技能
 -   [huangserva](https://github.com/huangserva/skill-prompt-generator)：生成和优化 AI 人像文生图提示词
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
+-   [html-anything](https://github.com/clockless-org/html-anything)：任意文件 / 导出 / 链接 → 单文件 HTML 网页，16 个设计系统自动选（教学站、地图册、时间线、关系图、document、developer 等），跨 Claude Code / Codex / Cursor / Windsurf；[在线 demo 廊](https://clockless-org.github.io/html-anything/examples/)
 
 ### 产品使用
 


### PR DESCRIPTION
添加 [`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) 到 **精选技能 → 内容创作**。

> **装一次。 当 agent 的回答内容本来就该是个"页面"而不是"消息"，它就把答案做成精致的网页。**

`html-anything` 把 agent 的复杂回答，以及任意文件 / 文件夹 / 链接 / 服务导出，变成单文件 HTML 网页。Skill 自动选 16 个设计系统之一（教学站、地图册、时间线、关系图、network map、document、developer 等），生成 HTML 并在浏览器里验证。短回答保持短。

**安装**：`npx skills add clockless-org/html-anything`

**在线 demo 廊**：https://clockless-org.github.io/html-anything/examples/

样例：[Kindle](https://clockless-org.github.io/html-anything/examples/kindle-highlights/output.html) · [太阳系教学](https://clockless-org.github.io/html-anything/examples/solar-system-studio/output.html) · [微信情侣分析](https://clockless-org.github.io/html-anything/examples/wechat-couple/output.html) · [Google Maps 收藏](https://clockless-org.github.io/html-anything/examples/google-maps-stars/output.html)

Apache 2.0 · 跨工具 · 34 个 source parser · 16 个设计系统