### PR TITLE
Add claude-persona to 其他类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ skillhub upgrade # 升级已安装的技能
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
+-   [claude-persona](https://github.com/takechanman1228/claude-persona)：构建 AI 虚拟用户画像面板，用于消费者研究和产品概念测试，灵感来自 TinyTroupe
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 
 


### PR DESCRIPTION
将 [claude-persona](https://github.com/takechanman1228/claude-persona) 添加到「其他类型」分类。

**功能简介**：受微软 [TinyTroupe](https://github.com/microsoft/TinyTroupe) 启发的 Claude Code 技能，用于构建 AI 虚拟用户画像面板，在投入真实田野调查之前先做定性研究和概念测试。

- `/persona generate` — 生成可复用的画像面板（包含多样化的人口统计、Big Five 性格特质、细分群体平衡）
- `/persona ask` — 开放式访谈，挖掘动机、阻碍和决策标准
- `/persona concept-test` — 结构化对比测试（A/B/C 概念、信息或功能）
- 每个 persona 在独立的 `claude -p` 子进程中运行（agent 隔离，避免群体偏差）
- 自动产出包含主题归纳、交叉表、图表和原始引文的研究报告

**为什么放在「其他类型」**：与 `marketingskills`、`scientific-skills` 一样面向特定专业人群（市场/产品/策略团队），不属于纯内容创作或产品操控类技能。

**链接**：
- 仓库：https://github.com/takechanman1228/claude-persona
- 许可证：MIT
- 安装：`/plugin marketplace add takechanman1228/claude-persona`
- 内置四个完整 Demo（Gen Z 护肤、高端巧克力、即饮饮料、运动鞋），含预生成的画像面板和完整结果

如分类或描述需要调整，欢迎建议。