### PR TITLE
添加 recsys-pipeline-architect（精选技能 / 编程开发）

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ skillhub upgrade # 升级已安装的技能
 -   [code-review](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)：代码审查技能
 -   [code-simplifier](hhttps://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier)：代码简化技能
 -   [commit-commands](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands)：Git 提交技能
+-   [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect)：基于 xAI 开源 X For You 算法的六阶段 Source→Hydrator→Filter→Scorer→Selector→SideEffect 框架，设计可组合的推荐、排序与 feed 流水线。附 Strapi v5（TypeScript）、Go（generics）、Python/FastAPI 三套可运行脚手架（共 9/9 测试通过）
 
 
 ### 内容创作


### PR DESCRIPTION
新增 [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) 到「精选技能 → 编程开发」分类。

一个跨平台的 Agent Skill（agentskills.io 标准），用于设计可组合的推荐、排序和 feed 流水线。基于 xAI 开源的 [X For You 算法](https://github.com/xai-org/x-algorithm) 推广的六阶段框架：**Source → Hydrator → Filter → Scorer → Selector → SideEffect**。MIT 许可证，是该模式的独立重新实现。

**仓库内容：**
- SKILL.md + 5 篇按需加载的参考文档（4 种语言的接口定义、多动作评分、候选隔离、12 种过滤器实现、评分器实现）
- 3 套可运行的示例脚手架（每套均通过测试）：
  - Strapi v5 插件（TypeScript / Jest — 3/3 通过）
  - Zentra 兼容流水线（Go 含 generics — 3/3 通过）
  - PMAI 任务优先级排序（Python / FastAPI / pytest — 3/3 通过）
- v0.1.0 release 已标记

**安装：** 通过 skills.sh 一行命令安装到 Claude Code、Codex、Cursor、Gemini CLI 等 17 个平台：
```bash
npx skills add mturac/recsys-pipeline-architect
```