### PR TITLE
新增 reading-widget 到「产品使用」

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ skillhub upgrade # 升级已安装的技能
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：操控 NotebookLM 
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
+-   [reading-widget](https://github.com/TinaDu-AI/reading-widget)：把微信读书数据渲染成 macOS 桌面小卡片（streak / 今日时长 / 在读书 / 金句），通过 Übersicht 悬浮在桌面壁纸层
 
 ### 其他类型
 


### PR DESCRIPTION
新增一个 macOS 桌面阅读 widget 到「产品使用」分类。

**项目地址**：https://github.com/TinaDu-AI/reading-widget

**简介**：基于微信读书官方 `weread-skills` 的渲染层，把阅读统计/书架/进度/热门划线接口的输出组合成一个挂在桌面壁纸层（通过 Übersicht）的小卡片：

- 连续阅读天数
- 今日/本月阅读时长 + 本月目标进度条
- 正在读的书 + 进度 %
- 今年读完本数、累计时长、笔记数
- 当前在读那本书的金句（按日期轮换）

完全建立在微信读书官方 Agent API 之上，不涉及任何接口逆向。

MIT License。