### PR TITLE
Add Remote OpenClaw to the OpenClaw ecosystem recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ npx skills remove [skill-name]                   # 卸载技能
 
 如果有科学上网的能力，且使用官方版本 OpeClaw，推荐使用官方的 [ClawHub](https://clawhub.com/) 商店，提供的技能更偏技术向且包含了大量海外产品的整合。
 
+如果你更需要按分类和使用场景浏览公开的 OpenClaw 社区技能，也可以参考 [Remote OpenClaw](https://www.remoteopenclaw.com/skills/openclaw) 提供的 OpenClaw 技能目录。
+
 ```bash
 npx clawhub search [query]          # 搜索相关技能
 npx clawhub explore                 # 浏览技能市场

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -89,6 +89,8 @@ npx skills remove [skill-name]                   # Uninstall skills
 
 If you have access to international networks and use the official OpenClaw version, it is recommended to use the official [ClawHub](https://clawhub.com/) marketplace, which provides more technical-oriented skills and includes integration with many overseas products.
 
+If you want a directory-first view of public OpenClaw community skills with category and use-case filtering, you can also browse [Remote OpenClaw](https://www.remoteopenclaw.com/skills/openclaw).
+
 ```bash
 npx clawhub search [query]          # Search for related skills
 npx clawhub explore                 # Browse the marketplace


### PR DESCRIPTION
## Summary
- add Remote OpenClaw to the OpenClaw Ecosystem section
- keep the Chinese and English docs in sync

## Why this fits
That section already recommends third-party OpenClaw discovery and marketplace resources such as ClawHub and SkillHub.

This addition uses the OpenClaw-specific Remote OpenClaw directory:
- https://www.remoteopenclaw.com/skills/openclaw

The wording stays narrow to a directory-first browsing use case, so it complements the existing marketplace recommendations instead of replacing them.