### PR TITLE
Add Bilig WorkPaper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ skillhub upgrade # 升级已安装的技能
 -   [code-review](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)：代码审查技能
 -   [code-simplifier](hhttps://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier)：代码简化技能
 -   [commit-commands](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands)：Git 提交技能
+-   [bilig-workpaper](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper)：公式驱动的 WorkPaper 技能，帮助 Agent 编辑单元格、重新计算、回读校验并持久化 JSON 工作簿逻辑
 
 
 ### 内容创作

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -220,6 +220,7 @@ skillhub upgrade                  # Upgrade installed skills
 -   [code-review](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review): Code review skills
 -   [code-simplifier](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier): Code simplification skills
 -   [commit-commands](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands): Git commit skills
+-   [bilig-workpaper](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper): Formula WorkPaper skill for agents to edit cells, recalculate, verify readback, and persist JSON workbook logic
 
 ### Content Creation
 


### PR DESCRIPTION
## Summary
- Adds Bilig WorkPaper to the Featured Skills programming/development section.
- Updates the Chinese README and English README.

## Why
Bilig provides a SKILL.md-backed WorkPaper workflow for agents to edit formula-backed workbook JSON, recalculate, verify readback, and persist state.