### PR TITLE
Add: ndesv21/socialclaw — 13平台社交媒体调度与发布

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ skillhub upgrade # 升级已安装的技能
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
+-   [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw)：通过单个工作区 API 密钥，跨 13 个平台（X、LinkedIn、Instagram、Facebook、TikTok、Discord、Telegram、YouTube、Reddit、WordPress、Pinterest）调度和发布社交媒体内容
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 
 


### PR DESCRIPTION
添加 [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) 到营销技能列表。

SocialClaw 是一个面向 AI Agent 的社交媒体发布技能，通过单个工作区 API 密钥，支持跨 13 个平台（X、LinkedIn、Instagram、Facebook、TikTok、Discord、Telegram、YouTube、Reddit、WordPress、Pinterest）调度和发布内容。

- 安装：`npx skills add ndesv21/socialclaw`
- 官网：https://getsocialclaw.com
- License: MIT