### PR TITLE
Add ii-commons skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ skillhub upgrade # 升级已安装的技能
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
+-   [ii-commons](https://github.com/Intelligent-Internet/II-Commons-Skills)：面向科研检索的 Agent Skill 与 npm CLI，支持 arXiv、PubMed/PMC 和美国政策语料的每日更新检索
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -243,6 +243,7 @@ skillhub upgrade                  # Upgrade installed skills
 -  [pua](https://github.com/tanweai/pua): Drive AI to work harder in a PUA style
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours): Provide startup advice from a YC perspective
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills): Enhance marketing capabilities
+-   [ii-commons](https://github.com/Intelligent-Internet/II-Commons-Skills): Agent skill and npm CLI for daily-updated retrieval across arXiv, PubMed/PMC, and supported US policy corpora
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills): Improve skills for researchers
 
 ## Security Audit


### PR DESCRIPTION
Adds ii-commons to the featured skills section in Chinese and English.\n\nii-commons is an open-source Agent Skill and npm CLI for daily-updated retrieval across arXiv, PubMed/PMC, and supported US policy corpora. It fits the research/scientific skill entries already present in this section.\n\nProject: https://github.com/Intelligent-Internet/II-Commons-Skills