### PR TITLE
Add UnifAPI KOL pricing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ skillhub upgrade # 升级已安装的技能
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
+-   [unifapi-agent/kol-pricing](https://github.com/unifapi-agent/skills/tree/main/skills/kol-pricing)：基于公开社交数据评估创作者合作报价
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -243,6 +243,7 @@ skillhub upgrade                  # Upgrade installed skills
 -  [pua](https://github.com/tanweai/pua): Drive AI to work harder in a PUA style
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours): Provide startup advice from a YC perspective
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills): Enhance marketing capabilities
+-   [unifapi-agent/kol-pricing](https://github.com/unifapi-agent/skills/tree/main/skills/kol-pricing): Price creator campaigns with public social data
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills): Improve skills for researchers
 
 ## Security Audit

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -243,6 +243,7 @@ skillhub upgrade                  # インストール済みスキルをアッ�
 -  [pua](https://github.com/tanweai/pua)：PUA スタイルで AI をより一生懸命働かせる
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：YC の視点から様々な起業アドバイスを提供
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：マーケティング能力を強化
+-   [unifapi-agent/kol-pricing](https://github.com/unifapi-agent/skills/tree/main/skills/kol-pricing)：公開ソーシャルデータでクリエイター案件の価格を評価
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)：研究者のスキルを向上
 
 ## セキュリティ監査


### PR DESCRIPTION
## Summary

Adds `unifapi-agent/kol-pricing` to the featured skill list and keeps the Chinese, English, and Japanese README variants in sync.

## Validation

- Verified the skill URL returns HTTP 200.
- Ran `git diff --check`.
