### PR TITLE
Add meta-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ skillhub upgrade # 升级已安装的技能
 ### 编程开发
 
 -   [superpowers](https://github.com/obra/superpowers)：涵盖完整编程项目工作流程
+-   [meta-skill](https://github.com/joohw/meta-skill)：用于评估、调研和设计 Agent Skill，在创建前明确边界、竞品差异和独特定位
 -   [frontend-design](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design)：前端设计技能
 -   [ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)：更精致和个性化的 UI/UX 设计
 -   [code-review](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)：代码审查技能


### PR DESCRIPTION
在精选技能中加入 meta-skill。\n\nmeta-skill 用于在创建 Agent Skill 前进行谨慎评估、竞品/邻近方案调研，并定义清晰的技能定位和独特性。