### PR TITLE
feat: add CreatorSkills marketplace to Claude App skill stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Skill 可以在 Claude 和 ChatGPT 这类 GUI 的 App 中使用，也可以在 C
 
 对于官方商店中没有的 Skill，可以从下方推荐的 Skill 第三方商店中下载并手动上传安装。
 
+-   [CreatorSkills](https://creatorskills.co)：专为内容创作者打造的 AI 技能市场，提供 YouTube 脚本写作、赞助商分析和受众增长等 30+ 款下载即用技能，支持 Claude 和 ChatGPT
+
 ### 类 Claude Code 生态
 
 ![](assets/media/skills_mp.png)


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the recommended third-party skill stores in the Claude App ecosystem section.

The current README mentions that users can find skills in third-party stores but lists no stores for Claude App users. CreatorSkills fills this gap — it's a marketplace of 30+ downloadable AI skills specifically for content creators (YouTube scripting, sponsorship analysis, audience growth), compatible with Claude and ChatGPT.

### Entry added (under 类 Claude App 生态 → 第三方商店)

```
- [CreatorSkills](https://creatorskills.co)：专为内容创作者打造的 AI 技能市场，提供 YouTube 脚本写作、赞助商分析和受众增长等 30+ 款下载即用技能，支持 Claude 和 ChatGPT
```