### PR TITLE
Add html2link publish skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ skillhub upgrade # 升级已安装的技能
 -   [wps](https://github.com/wpsnote/wpsnote-skills)：操控 WPS 办公软件
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：操控 NotebookLM 
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
+-   [html2link-publish](https://github.com/joohw/html2link-skill)：将 HTML、Markdown、PDF、表格、DOCX、PPTX 和静态站点发布成可分享短链接
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 
 ### 其他类型


### PR DESCRIPTION
## Summary

在“产品使用”分类中添加 `html2link-publish`。

## Why

这个 Skill 可以帮助 Claude Code / Codex 等 agent 将生成的 HTML、Markdown、PDF、表格、DOCX、PPTX 和静态站点发布成 html2link.dev 可分享短链接，适合作为 agent 交付产物的轻量发布工具。

## Links

- Skill repo: https://github.com/joohw/html2link-skill
- Live example: https://html2link.dev/x/yeiEwrKr

## Verification

- `npx skills add joohw/html2link-skill --list` 可以识别 `html2link-publish`
- `SKILL.md` 已通过 Codex skill validator