### PR TITLE
feat: add NotFair — SEO, Google Ads & Meta Ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ skillhub upgrade # 升级已安装的技能
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
+-   [NotFair](https://github.com/nowork-studio/NotFair)：面向 Claude Code 的开源营销技能集，覆盖 [SEO](https://github.com/nowork-studio/NotFair/tree/main/skills/seo)、[Google Ads](https://github.com/nowork-studio/NotFair/tree/main/skills/google-ads)、[Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/skills/meta-ads)，通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 接入实时数据
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a great reference for the agent-skills ecosystem.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) to the **其他类型** section, next to the existing `marketingskills` entry. NotFair is an open-source set of Claude Code skills (~2.9k stars, MIT license) focused on marketing work. It covers SEO site analysis, keyword research, meta tags, schema markup, and GEO optimization, as well as Google Ads audits and Meta (Facebook + Instagram) Ads analysis. It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

The fit felt natural: this list collects agent skills for Claude Code and similar ecosystems, and NotFair is exactly that — a skill collection for a specific vertical (marketing / paid ads / SEO).

Happy to move it to a different section, trim the description, or adjust wording if needed. Thank you!