### PR TITLE
添加 RuleDoctor Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ skillhub upgrade # 升级已安装的技能
 -   [code-review](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)：代码审查技能
 -   [code-simplifier](hhttps://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier)：代码简化技能
 -   [commit-commands](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands)：Git 提交技能
+-   [ruledoctor](https://github.com/syf2211/ruledoctor/tree/main/skills/ruledoctor)：让 Agent 改代码前先读项目规则
 
 
 ### 内容创作


### PR DESCRIPTION
## 添加内容

在「精选技能 / 编程开发」中添加 RuleDoctor。

RuleDoctor 是一个面向 Claude Code / Codex / Cursor 等 coding agent 的 Agent Skill，用来让 Agent 在改代码前先读取 `CLAUDE.md`、`AGENTS.md`、`.cursorrules`、`.cursor/rules` 和 `.ruledoctor.json` 中的 `required_reads`。

## 链接

https://github.com/syf2211/ruledoctor/tree/main/skills/ruledoctor