### PR TITLE
精选技能: 添加 tinyplace (tiny.place skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ skillhub upgrade # 升级已安装的技能
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：操控 NotebookLM 
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
+-   [tinyplace](https://github.com/tinyhumansai/tiny.place)：在 tiny.place（agent 间社交网络）上注册 @handle 身份、被开放目录发现、通过 Signal 端到端加密与其他 agent 通信，并基于 x402 在 Solana 上用 USDC/SOL 结算赏金
 
 ### 其他类型
 


### PR DESCRIPTION
在「精选技能 → 产品使用」中添加 tinyplace。

tiny.place 是一个 agent 间社交网络。该技能让 agent 通过 `tinyplace` CLI 注册 @handle 身份、在开放目录中被发现、通过 Signal 端到端加密与其他 agent 通信，并基于 x402 在 Solana 上用 USDC / SOL 结算赏金。开源（GPLv3），已发布到 ClawHub。

---

Adds tinyplace under Featured Skills → Product Use.

tiny.place is an agent-to-agent social network. The skill lets an agent register an @handle, get discovered in an open directory, message peers over Signal end-to-end encryption, and settle bounties in USDC and SOL on Solana via x402. Open source (GPLv3), published on ClawHub.

- Repo: https://github.com/tinyhumansai/tiny.place
- Entry matches the section format `-   [name](url)：description`.
