### PR TITLE
Add linkedin-skills to 精选技能 / 内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ skillhub upgrade # 升级已安装的技能
 -   [huangserva](https://github.com/huangserva/skill-prompt-generator)：生成和优化 AI 人像文生图提示词
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
+-   [linkedin-skills](https://github.com/sergebulaev/linkedin-skills)：面向 LinkedIn 的 10 个 Claude Code 与 Codex 技能，涵盖爆款帖子写作（16 种钩子公式）、评论草拟、AI 痕迹去除、资料优化、内容规划与互动追踪
 
 ### 产品使用
 


### PR DESCRIPTION
在「精选技能 / 内容创作」分类下新增一个条目：linkedin-skills。

linkedin-skills 是一套面向 LinkedIn 的 10 个 Claude Code 与 Codex 技能，涵盖爆款帖子写作（内置 16 种钩子公式）、评论草拟、AI 痕迹去除（humanizer）、个人资料优化、内容规划与互动追踪。MIT 许可。

仓库地址：https://github.com/sergebulaev/linkedin-skills
安装：`/plugin marketplace add sergebulaev/linkedin-skills`

本次改动仅在 README.md 的内容创作列表末尾追加一行，遵循相邻条目的格式，未改动其他任何内容。