### PR TITLE
Add ai-meeting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ skillhub upgrade # 升级已安装的技能
 
 ### 编程开发
 
+-   [ai-meeting-skill](https://github.com/bin1874/ai-meeting-skill)：组织 Codex、Claude 等 AI agent 进行多轮会议讨论，保留各 agent 会话上下文并输出结构化最终报告
 -   [superpowers](https://github.com/obra/superpowers)：涵盖完整编程项目工作流程
 -   [frontend-design](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design)：前端设计技能
 -   [ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)：更精致和个性化的 UI/UX 设计

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -214,6 +214,7 @@ skillhub upgrade                  # Upgrade installed skills
 
 ### Programming & Development
 
+-   [ai-meeting-skill](https://github.com/bin1874/ai-meeting-skill): Organize multi-round AI meetings with Codex, Claude, and other agents while preserving per-agent sessions and producing structured final reports
 -   [superpowers](https://github.com/obra/superpowers): Complete programming project workflow
 -   [frontend-design](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/frontend-design): Frontend design skills
 -   [ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill): More refined and personalized UI/UX design


### PR DESCRIPTION
Adds bin1874/ai-meeting-skill to the featured skills list in both Chinese and English READMEs.

ai-meeting organizes multi-round AI meetings with Codex, Claude, and other agents, preserving per-agent session context and producing structured final reports.

Validation:
- Ran `git diff --check`.