### PR TITLE
Add routerbase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ skillhub upgrade # 升级已安装的技能
 -   [wps](https://github.com/wpsnote/wpsnote-skills)：操控 WPS 办公软件
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：操控 NotebookLM 
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
+-   [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills)：通过 [routerbase](https://routerbase.com/) 使用 OpenAI 兼容网关、模型路由与媒体生成
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 
 ### 其他类型

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -236,6 +236,7 @@ skillhub upgrade                  # Upgrade installed skills
 -   [wps](https://github.com/wpsnote/wpsnote-skills): Control WPS office software
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py): Control NotebookLM
 -   [n8n](https://github.com/czlonkowski/n8n-skills): Create n8n workflows
+-   [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills): Use [routerbase](https://routerbase.com/) as an OpenAI-compatible gateway for model routing and media generation
 -   [threejs](https://github.com/cloudai-x/threejs-skills): Assist with Three.js development
 
 ### Other Types

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -236,6 +236,7 @@ skillhub upgrade                  # インストール済みスキルをアッ�
 -   [wps](https://github.com/wpsnote/wpsnote-skills)：WPS オフィスソフトを操作
 -   [notebooklm](https://github.com/teng-lin/notebooklm-py)：NotebookLM を操作
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：n8n ワークフローを作成
+-   [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills)：[routerbase](https://routerbase.com/) を OpenAI 互換ゲートウェイ、モデルルーティング、メディア生成に使用
 -   [threejs](https://github.com/cloudai-x/threejs-skills)：Three.js プロジェクト開発を支援
 
 ### その他


### PR DESCRIPTION
Adds routerbase-agent-skills to the product usage recommendations in the Chinese, English, and Japanese READMEs.\n\nThe repository includes three Agent Skills for using routerbase as an OpenAI-compatible gateway, model routing layer, and media generation interface.\n\nSource: https://github.com/zenlee123/routerbase-agent-skills\nWebsite: https://routerbase.com/\n\nValidation:\n- Checked the repository for existing routerbase entries\n- Updated README.md, docs/README_EN.md, and docs/README_JA.md\n- Checked for accidental private email or real API key leakage\n- Ran git diff --check