### PR TITLE
Add Linked API linkedin skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ skillhub upgrade # 升级已安装的技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 
+-   [linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)：Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
 ### 其他类型
 
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin`.

- Skill: General LinkedIn automation
- Listing name: linkedin-skills
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin
- Docs: https://linkedapi.io/skills/linkedin-skill
- Install runbook: https://linkedapi.io/skills/linkedin/install.md
- Description: Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
- Tags: LinkedIn, automation, social, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/libukai-awesome-agent-skills.md

Publication copy:
LinkedIn Skill gives AI agents natural-language access to LinkedIn automation through Linked API. It supports profile and company research, people and company search, messaging, connection requests and management, post creation, reactions, comments, stats, Sales Navigator actions, and custom workflows. It works with Claude Code, Codex, Cursor, and Windsurf and uses dedicated cloud browsers through Linked API.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-skill.png (https://linkedapi.io/skills/linkedin-skill)