### PR TITLE
Add Linked API linkedin-growth skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ skillhub upgrade # 升级已安装的技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 
+-   [linkedin-growth](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth)：Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
 ### 其他类型
 
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活


### PR DESCRIPTION
Adds Linked API skill listing for `linkedin-growth`.

- Skill: Lead pipeline (import → qualify → invites)
- Listing name: linkedin-growth
- Source: https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth
- Docs: https://linkedapi.io/skills/linkedin-growth-skill
- Install runbook: https://linkedapi.io/skills/linkedin-growth/install.md
- Description: Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
- Tags: LinkedIn, lead-generation, growth, agent-skill
- Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/libukai-awesome-agent-skills.md

Publication copy:
LinkedIn Growth is an agent skill for hands-off, controlled LinkedIn network growth. The user defines a LinkedIn or Sales Navigator search plus an ideal-lead profile; the skill imports candidates, qualifies every lead with recorded reasoning, stores the pipeline locally, assigns leads across one or more accounts, sends connection invites during active hours, tracks acceptances, and withdraws unanswered requests. It is built for steady qualified growth rather than one-off blasting.

Assets:
- Logo: assets/logo.png (https://linkedapi.io/logo.png)
- Social card: assets/social-card.png (https://linkedapi.io/opengraph-image?b7d7037e63c6122a)
- Screenshot: assets/screenshots/linkedin-growth-skill.png (https://linkedapi.io/skills/linkedin-growth-skill)