### PR TITLE
Add Linked API skills: linkedin, linkedin-growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ skillhub upgrade # 升级已安装的技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 
+-   [linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)：Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
+-   [linkedin-growth](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth)：Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
 ### 其他类型
 
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活


### PR DESCRIPTION
Adds the following Linked API agent skill listings in a single PR.

- General LinkedIn automation (linkedin-skills): Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
- Lead pipeline (import → qualify → invites) (linkedin-growth): Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.

Source: https://github.com/Linked-API/linkedin-skills
Catalog state: /Users/kiril/Documents/Work/LinkedAPI/.claude/skills/publish-skills/catalogs/libukai-awesome-agent-skills.md