### PR TITLE
Add Maoxuan Product Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ skillhub upgrade # 升级已安装的技能
 
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
+-   [maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent)：从《矛盾论》《实践论》的推理结构蒸馏而来，面向需求、增长、数据、项目与协作问题的中文产品决策 Agent Skill
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -242,6 +242,7 @@ skillhub upgrade                  # Upgrade installed skills
 
 -  [pua](https://github.com/tanweai/pua): Drive AI to work harder in a PUA style
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours): Provide startup advice from a YC perspective
+-   [maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent): Chinese product decision Agent Skill distilled from the reasoning structures of *On Contradiction* and *On Practice*, covering requirements, growth, data, delivery, and collaboration
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills): Enhance marketing capabilities
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills): Improve skills for researchers
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -242,6 +242,7 @@ skillhub upgrade                  # インストール済みスキルをアッ�
 
 -  [pua](https://github.com/tanweai/pua)：PUA スタイルで AI をより一生懸命働かせる
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：YC の視点から様々な起業アドバイスを提供
+-   [maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent)：『矛盾論』『実践論』の推論構造から蒸留した中国語のプロダクト意思決定 Agent Skill。要件、成長、データ、プロジェクト、協業の課題に対応
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：マーケティング能力を強化
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)：研究者のスキルを向上
 


### PR DESCRIPTION
## Summary

- Add `maoxuan-product-agent` to the featured skills list under Other Types
- Keep the Chinese, English, and Japanese README mirrors aligned

## Why it fits

Maoxuan Product Agent is an open-source Chinese product decision Agent Skill distilled from the reasoning structures of *On Contradiction* and *On Practice*. It turns real requirements, growth, data, delivery, and collaboration problems into direct judgments and next actions, while keeping source quotations and historical language out of normal product-work output.

The repository includes multi-agent installation instructions, 36+ evaluation scenarios, a quality gate, and a searchable case library.

## Checks

- `git diff --check`
- Confirmed exactly one listing in each README mirror
- Confirmed the repository URL returns HTTP 200
