### PR TITLE
添加 Ditto 个性化 Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ skillhub upgrade # 升级已安装的技能
 
 -  [pua](https://github.com/tanweai/pua)：以 PUA 的方式驱动 AI 更卖力的干活
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
+-   [ditto](https://github.com/ohad6k/ditto)：从真实的 Claude Code、Codex 和 Copilot CLI 会话历史中提炼个人工作、设计和写作偏好，并生成可安装的 Agent Skills
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
 


### PR DESCRIPTION
## 说明

在「其他类型」中加入 [Ditto](https://github.com/ohad6k/ditto)。Ditto 从用户真实的 Claude Code、Codex 和 Copilot CLI 本地会话历史中，提炼重复出现的决策、拒绝模式和完成标准，生成工作、设计和写作 Agent Skills。

## 核验

- GitHub 链接公开可访问
- 项目使用 MIT 许可证
- 支持标准 `SKILL.md`、Claude Code、Codex 和 GitHub Copilot 插件清单
- `git diff --check -- README.md` 通过