### PR TITLE
新增 china-factory-search（中国工厂搜索技能）

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ skillhub upgrade # 升级已安装的技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [china-factory-search](https://github.com/InequalTech/china-factory-search)：在 480 万家经过识别的中国真实工厂中找厂、查档案、拿联系方式（天下工厂开放平台，MCP + REST）
 
 
 ## 安全审查


### PR DESCRIPTION
在「精选技能 → 其他类型」新增 china-factory-search：在 480 万家经过识别的中国真实工厂中按行业/地域/规模找厂，查完整档案与联系方式，支持自然语言找厂。

- 安装：`npx skills add InequalTech/china-factory-search`
- 也可直接接 MCP：`https://open.tianxiagongchang.com/open/mcp`（已入官方 MCP Registry）
- 文档带公开沙箱 key，零成本跑通链路