### PR TITLE
添加 rote 到精选技能 / 编程开发

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ gh skill publish                                 # 校验并发布技能
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad)：面向 CAD、CAE 与 CAM 的工程技能库
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill)：跨平台桌面应用的原生体验设计指南
+-   [rote](https://github.com/trevhud/rote)：将验证过的技能编译为确定性流水线，固定逻辑转为带测试的 Python/TypeScript 代码
 
 
 ### 内容创作


### PR DESCRIPTION
在「精选技能 > 编程开发」末尾添加 [rote](https://github.com/trevhud/rote)。

rote 是一个开源 CLI（Apache-2.0，Python 3.11+，`pip install rote-cli`），把已经验证过的技能（一个 SKILL.md 加上 references）编译成确定性流水线：固定逻辑被抽取成带单步测试的 Python 或 TypeScript 代码，只有真正需要判断的步骤保留为带类型签名的 LLM judge，因此大部分流程运行时不再需要 LLM。

仓库本身也提供两个符合 SKILL.md 标准的技能：`compile`（运行编译）和 `serve`（把编译产物注册为 MCP 工具）。编译产物可以输出为 DBOS、Temporal、Cloudflare Workflows、Inngest 或纯 Python/TypeScript。

- 仓库：https://github.com/trevhud/rote
- 文档：https://roteskills.com
- PyPI：https://pypi.org/project/rote-cli/

这是一个新项目，目前还没有什么关注度。本 PR 只改动 README 中的一行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)