### PR TITLE
添加 OrkasVideoStudio 内容创作技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ gh skill publish                                 # 校验并发布技能
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
 -   [cangjie-skill](https://github.com/kangarooking/cangjie-skill)：把书、视频和播客蒸馏为可执行的 Agent Skills
+-   [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio)：面向 Codex、Claude Code 和 MCP 的视频制作技能集，可编排、编辑、生成并自动组装视频
 
 ### 产品使用
 


### PR DESCRIPTION
## 变更说明

- 在「精选技能 / 内容创作」中添加 OrkasVideoStudio
- 说明其面向 Codex、Claude Code 和 MCP 的视频制作技能集
- 链接到包含可安装技能源码的官方仓库

## 验证

- 已确认列表中没有现有 OrkasVideoStudio 条目
- `git diff --check`