### PR TITLE
添加 liuyao-quanjie 技能（易经六爻排盘与全解）

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ gh skill publish                                 # 校验并发布技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [liuyao-quanjie](https://github.com/qimister-code/liuyao-quanjie)：易经六爻排盘与全解（京房纳甲），铜钱起卦 + 完整排盘 + 64 卦知识库，零依赖
 
 
 ## 安全审查


### PR DESCRIPTION
在「其他类型」分类新增 [liuyao-quanjie](https://github.com/qimister-code/liuyao-quanjie)：易经六爻（京房纳甲）排盘与全解 Agent Skill，铜钱起卦 + 零依赖排盘 CLI + 64 卦完整知识库（含化解指南）+ 13 张 SVG 图。代码 MIT、内容 CC BY-NC-SA 双许可。