### PR TITLE
Add agent-skill-manager: cross-platform skill sync for 9 Chinese AI agent products

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ gh skill publish                                 # 校验并发布技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 -   [skills-manage](https://github.com/iamzhihuix/skills-manage)：跨多种 Agent 管理本地 Skills
+-   [agent-skill-manager](https://github.com/yxdwind/agent-skill-manager)：跨平台（macOS/Windows）管理 9 个国产 AI Agent 产品的 Skill 同步与分发
 
 ### 其他类型
 


### PR DESCRIPTION
## 新增项目

[agent-skill-manager](https://github.com/yxdwind/agent-skill-manager) — 跨平台（macOS/Windows）统一管理国内 AI Agent 产品的 Skill 安装与同步。

### 核心能力

- **中央仓库 + 一键分发**：所有 Skill 统一存放在 \~/.agents/skills/\，通过 symlink/junction 自动分发到各产品
- **支持 9 个国产 AI Agent 产品**：AutoClaw、Kimi Code、MiniMax Code、WorkBuddy、Trae Solo、DuMate、CodeBuddy（腾讯）、Comate/文心快码（百度）、Qoder/通义灵码（阿里）
- **零依赖**：仅使用 Python 标准库，macOS 和 Windows 开箱即用
- **34 个测试**：完整的产品定义、工具函数和核心逻辑测试

### 放置位置

放在「产品使用」分类下，紧邻 [skills-manage](https://github.com/iamzhihuix/skills-manage)。两者定位类似但互补：skills-manage 面向国际产品，agent-skill-manager 专注国产产品。

### 分类

产品使用 / Skill 管理