### PR TITLE
docs: 收录 using-lwc Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ gh skill publish                                 # 校验并发布技能
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad)：面向 CAD、CAE 与 CAM 的工程技能库
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill)：跨平台桌面应用的原生体验设计指南
+-   [using-lwc](https://github.com/JanYork/using-lwc)：为编码 Agent 提供持久项目记忆与可验证的文档、代码双图谱
 
 
 ### 内容创作


### PR DESCRIPTION
在“精选技能 → 编程开发”中收录 `using-lwc`。

该 Skill 面向编码 Agent，提供持久项目记忆以及可独立验证的文档图谱和代码图谱。源仓库公开，包含标准 `SKILL.md`。