### PR TITLE
添加 SandBase Agent Skills 项目

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ gh skill publish                                 # 校验并发布技能
 <td><a href="https://github.com/wpsnote/wpsnote-skills">wps</a></td>
 <td><a href="https://github.com/marswaveai/skills">listenhub</a></td>
 <td><a href="https://github.com/larksuite/cli">lark</a></td>
-<td></td>
+<td><a href="https://github.com/sandbaseai/sandbase-skills">sandbase</a></td>
 </tr>
 </table>
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -233,7 +233,7 @@ gh skill publish                                 # Validate and publish a Skill
 <td><a href="https://github.com/wpsnote/wpsnote-skills">wps</a></td>
 <td><a href="https://github.com/marswaveai/skills">listenhub</a></td>
 <td><a href="https://github.com/larksuite/cli">lark</a></td>
-<td></td>
+<td><a href="https://github.com/sandbaseai/sandbase-skills">sandbase</a></td>
 </tr>
 </table>
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -233,7 +233,7 @@ gh skill publish                                 # Skill を検証して公開
 <td><a href="https://github.com/wpsnote/wpsnote-skills">wps</a></td>
 <td><a href="https://github.com/marswaveai/skills">listenhub</a></td>
 <td><a href="https://github.com/larksuite/cli">lark</a></td>
-<td></td>
+<td><a href="https://github.com/sandbaseai/sandbase-skills">sandbase</a></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## 变更

在“官方项目 → 内容与协作”表格中加入 `sandbaseai/sandbase-skills`，并同步更新中文、英文和日文 README。

该公开 Apache-2.0 仓库提供 88 个可安装 Agent Skills，覆盖研究、社交情报、营销和商业工作流，并支持 Claude Code、Codex、Cursor 和 Gemini CLI。

## 验证

- 已确认仓库公开、未归档且许可证可识别为 Apache-2.0
- 三种语言表格保持相同链接和五列结构
- `git diff --check` 通过

披露：我与 SandBase 项目有关联。