### PR TITLE
添加 Agent QA 测试 Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ gh skill publish                                 # 校验并发布技能
 ### 编程开发
 
 -   [superpowers](https://github.com/obra/superpowers)：涵盖完整编程项目工作流程
+-   [agent-qa skills](https://github.com/vostride/agent-qa/tree/main/.agents/skills)：用于编写、运行和审查自然语言 Web / 移动端测试的三项 Agent Skills，并可配合 Agent QA CLI 与 MCP
 -   [frontend-design](https://github.com/anthropics/skills/tree/main/skills/frontend-design)：前端设计技能
 -   [ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)：更精致和个性化的 UI/UX 设计
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ gh skill publish                                 # 校验并发布技能
 ### 编程开发
 
 -   [superpowers](https://github.com/obra/superpowers)：涵盖完整编程项目工作流程
--   [agent-qa skills](https://github.com/vostride/agent-qa/tree/main/.agents/skills)：用于编写、运行和审查自然语言 Web / 移动端测试的三项 Agent Skills，并可配合 Agent QA CLI 与 MCP
+-   [agent-qa skills](https://github.com/vostride/agent-qa/tree/main/skills)：用于编写、运行和审查自然语言 Web / 移动端测试的三项 Agent Skills，可配合 Agent QA CLI 与 MCP；采用 FSL-1.1-ALv2 源码可用许可证
 -   [frontend-design](https://github.com/anthropics/skills/tree/main/skills/frontend-design)：前端设计技能
 -   [ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)：更精致和个性化的 UI/UX 设计
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图


### PR DESCRIPTION
## 概要

在“精选技能 → 编程开发”中加入 Agent QA 的三项标准 Agent Skills：

- `agent-qa-authoring`：编写符合 schema 的测试、套件与 hooks
- `agent-qa-result-triage`：基于执行证据判断失败原因
- `agent-qa-debug-fix`：进行有范围约束的修复与窄验证

条目直接链接到 [Agent QA 官方仓库中的 skills 目录](https://github.com/vostride/agent-qa/tree/main/skills)，并说明可配合项目的 CLI 与 MCP 使用。Agent QA 是面向软件团队的自改进 QA Agent，可执行自然语言 Web / 移动端测试。

## 验证

- `git diff --check`
- 已通过 GitHub API 确认 `skills/` 目录及三项技能目录可访问
- README 条目链接与 PR 说明均使用当前 `skills/` 路径

## 许可证与执行说明

Agent QA 当前采用 FSL-1.1-ALv2 源码可用许可证，每个版本在发布两年后转换为 Apache-2.0。

这些技能可调用 Agent QA CLI / MCP 执行测试。安装涉及 npm 包；浏览器和移动端测试会操作目标应用；可选 hooks 在 Docker 中执行脚本。应只对获授权的测试目标使用，并在执行前检查测试、hooks、凭据与 MCP 权限。配置的模型或云端浏览器/设备服务可能另外收费。

Disclosure: I am affiliated with Agent QA and Vostride.
