### PR TITLE
添加 apitube-news-api 到精选技能 / 产品使用

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ gh skill publish                                 # 校验并发布技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 -   [skills-manage](https://github.com/iamzhihuix/skills-manage)：跨多种 Agent 管理本地 Skills
+-   [apitube-news-api](https://github.com/apitube/news-api-skills/tree/main/skills/apitube-news-api)：调用 APITube News API 检索全球新闻，支持关键词、实体、情感与地域筛选
 
 ### 其他类型
 


### PR DESCRIPTION
在 **精选技能 / 产品使用** 一节新增一条记录（+1/−0，只改 `README.md`）。

| | |
|---|---|
| 技能 | [`apitube-news-api`](https://github.com/apitube/news-api-skills/tree/main/skills/apitube-news-api) |
| 仓库 | https://github.com/apitube/news-api-skills （MIT） |
| 结构 | 单个 `SKILL.md`；另附 `.claude-plugin/marketplace.json` 供 Claude Code 使用 |
| 安装 | `npx skills add apitube/news-api-skills --skill apitube-news-api` |

### 这个技能做什么

让 Agent 直接调用 [APITube](https://apitube.io) News API 检索全球新闻，而不用猜参数名：

- **鉴权**三种方式：`Authorization: Bearer`、`X-API-Key`、`api_key` 查询参数（并说明为什么优先用请求头）。
- **端点**：`/news/everything`、`/news/top-headlines`、`/news/count`、`/news/article`、`/news/story/{id}`、`/news/trends`、`/news/local`、`/news/raw`，以及 `/people`、`/companies`、`/journalists` 等资料型端点。
- **筛选**：关键词、实体、情感区间、来源与来源质量排名、国家、语言、分类、时间范围；分页、限流与错误码也一并写清。
- **典型场景**：媒体与品牌监测、市场情报，或给 RAG 管道提供实时新闻，替代抓取 HTML。

### 为什么放在「产品使用」

这一节收录的是操控某个具体产品/服务的技能（`wps`、`notebooklm`、`n8n`、`threejs`），本条属于同一类——调用一个具体的新闻数据服务。如果你认为放「内容创作」（与 `cclank/news-aggregator-skill` 相邻）更合适，我改这个分支即可。

### 说明

- 技能里的每个参数、字段、限制和错误码都对着线上 `api.apitube.io` 实跑验证过，不是照文档抄的。
- 免费额度 100 次/天，无需绑卡；`api_test_` 前缀的测试密钥查同一份数据且不消耗额度，所以不订阅也能用。
- **利益披露**：APITube 是我们自己的产品，这是厂商自研技能，主动说明，不冒充第三方。
- 只在「产品使用」列表末尾加了一行，没有改动其他内容。英文和日文 README 需要同步的话，我可以在同一分支补上。
