### PR TITLE
新增 dark-psychology-skills（销售谈判类 Agent Skills）

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ gh skill publish                                 # 校验并发布技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)：从36本书逐页蒸馏的13个销售谈判Agent技能（CIA心理战手册、FBI行为研究、宣传学、说服经典），所有技巧通过诚实影响力过滤：完全公开后依然有效
 
 
 ## 安全审查


### PR DESCRIPTION
在「其他类型」分类新增 [dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)。

13 个销售与谈判 Agent 技能（标准 SKILL.md 格式），从 36 本书逐页蒸馏：CIA 心理战手册、FBI 行为研究（The Like Switch）、宣传学（Ellul）、以及直接回应式说服经典（Hopkins、Schwartz、Sugarman、Halbert、Kennedy）。

- MIT 许可，CI 校验结构
- 纯英文易读写法，含 deal-router 决策树技能
- 诚实影响力过滤：所有技巧必须"完全公开后依然有效"，操控类内容仅作为防御材料收录

如需调整分类或措辞请告知。