### PR TITLE
Add resume-pipeline skill to 内容创作

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ gh skill publish                                 # 校验并发布技能
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
 -   [cangjie-skill](https://github.com/kangarooking/cangjie-skill)：把书、视频和播客蒸馏为可执行的 Agent Skills
+-   - [resume-pipeline](https://github.com/winsiehuang499-ui/resume-pipeline)：定制化简历专家——经历证据库 × 专属红线 × 单文件 HTML 在线简历，按 JD 快速出定制版
+
 
 ### 产品使用
 


### PR DESCRIPTION
## 新增：resume-pipeline（定制化简历专家 skill）

- 仓库：https://github.com/winsiehuang499-ui/resume-pipeline
- 一句话：从经历深挖 → 专属红线定制 → 按 JD 生成单文件 HTML 在线简历的完整流水线
- 结构：SKILL.md + 8 references（证据库/红线/撰写方法论/自检/交付）+ check_resume.js 自检脚本
- 特点：不编造（证据纪律）、红线用户自产、示例全部虚构（零个人信息）、零依赖 HTML 产出
- 写作方法论已注明引用自 resume-builder（MIT）

已在「内容创作」分类下添加一行条目，格式与现有条目一致。