### PR TITLE
Add falsify: scientific thinking protocol skill for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ gh skill publish                                 # 校验并发布技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [falsify](https://github.com/263311487-ux/falsify)：给 AI 智能体安装科学思维协议——先证伪，再相信；先标不确定，再下结论（支持 Codex / Claude Code / DeepSeek Harness / Cursor 等 20+ 智能体，含 28 个评测用例）
 
 
 ## 安全审查


### PR DESCRIPTION
## 新增技能

[falsify](https://github.com/263311487-ux/falsify) — 给 AI 智能体安装科学思维协议：

- **核心**: 先证伪，再相信；先标不确定，再下结论（无可证伪假设就没有结论）
- **兼容**: Codex / Claude Code / DeepSeek Harness / Cursor / Gemini CLI 等 20+ 智能体，单一 Markdown 即装即用
- **可验证**: 内置 28 个评测用例（evals/cases.md），每条结论带证据强度分级
- **质量**: 蒸馏自 70+ 社区来源与认知科学/因果推断文献，MIT 协议
- **安装**: `npx falsify-skill` 或 skills.sh 一键安装

已加入「其他类型」分类。