### PR TITLE
Add SandBase CLI Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ gh skill publish                                 # 校验并发布技能
 -   [n8n](https://github.com/czlonkowski/n8n-skills)：创建 n8n 工作流
 -   [threejs](https://github.com/cloudai-x/threejs-skills)： 辅助开发 Three.js 项目
 -   [skills-manage](https://github.com/iamzhihuix/skills-manage)：跨多种 Agent 管理本地 Skills
+-   [SandBase CLI](https://github.com/sandbaseai/cli/tree/main/skills/sandbase)：官方 SandBase Skill 与 MCP 桥接，连接受支持的 AI 客户端和 2,000+ AI 模型及 API
 
 ### 其他类型
 


### PR DESCRIPTION
在“精选技能 / 产品使用”中加入官方 SandBase Skill。

- Skill 来源：https://github.com/sandbaseai/cli/tree/main/skills/sandbase
- 官方文档说明其提供本地 MCP 桥接，可连接受支持的 AI 客户端和 2,000+ AI 模型及 API。
- 条目遵循当前中文清单格式。
- 披露：我与 SandBase 有关联，并使用 AI 辅助准备此事实性条目。