### PR TITLE
Add d1v deploy skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ gh skill publish                                 # 校验并发布技能
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad)：面向 CAD、CAE 与 CAM 的工程技能库
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill)：跨平台桌面应用的原生体验设计指南
+-   [d1v](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md)：部署 Web 项目，提供可验证的预览和需明确确认的生产发布
 
 
 ### 内容创作


### PR DESCRIPTION
## Summary

- add the official d1v deployment Skill to the featured programming and development list
- link to the public canonical `SKILL.md` in `d1vai/d1v-cli`

The Skill covers verified preview deployments and production releases requiring explicit confirmation.