### PR TITLE
精选技能/内容创作：新增 agent-skills-zh

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ gh skill publish                                 # 校验并发布技能
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
 -   [cangjie-skill](https://github.com/kangarooking/cangjie-skill)：把书、视频和播客蒸馏为可执行的 Agent Skills
+-   [agent-skills-zh](https://github.com/hanzhangzzz/agent-skills-zh)：英文技术文档精准翻译、公众号/小红书/X 内容存档为 Markdown、公众号排版发布，Claude Code 与 Codex 通用
 
 ### 产品使用
 


### PR DESCRIPTION
在「精选技能 → 内容创作」新增 [hanzhangzzz/agent-skills-zh](https://github.com/hanzhangzzz/agent-skills-zh)：面向中文开发者的 Agent Skills 集合（MIT，Claude Code 与 Codex 通用，`npx skills add hanzhangzzz/agent-skills-zh` 一键安装），内容创作相关能力包括：

- doc-reader：英文技术文档/PDF 章节级精准翻译为中文，图片 100% 保留，生成原文·译文·AI 幻灯片三栏预览
- wechat-article-md-local / xiaohongshu-downloader / x-article-download：公众号、小红书、X 内容存档为本地 Markdown（小红书含 Whisper 口播逐字稿）
- hkr-render：公众号排版（7 个主题）→ 封面 → 推送草稿箱
- md2view：Markdown 重编码为可溯源的双栏阅读视图

条目格式与现有列表一致，链接已验证。