### PR TITLE
添加 personal-understanding（证据链式个人记忆技能）

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ gh skill publish                                 # 校验并发布技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [personal-understanding](https://github.com/caix84476-netizen/personal-understanding)：证据链式个人记忆技能——先把用户原话不动地保存（SHA-256 校验、不可变），再从原话推导事件、实体和因果假设，每条结论都能追溯到出处；本地优先、零依赖、中英双语。
 
 
 ## 安全审查


### PR DESCRIPTION
## 新增技能

添加 **[personal-understanding](https://github.com/caix84476-netizen/personal-understanding)** —— 证据链式个人记忆技能。

核心思想：先把用户原话**不可变地保存**（SHA-256 校验、带时间戳和会话标记），再从原话推导事件、实体、情境卡和因果假设；每条派生结论都能一路追溯到原始引文，杜绝"摘要丢了出处"的常见记忆问题。

- 完全本地优先，一个文件夹，仅用 Python 标准库，零 pip 依赖
- 兼容 Claude Code、Codex、VS Code/Cursor/Windsurf/Cline/Trae、ZCode 和任意 MCP 客户端
- 带硬性"派生闭环"校验和本地审计面板
- 中英双语（`SKILL.md` / `SKILL.zh-CN.md`）
- MIT 协议，同步发布在 [PyPI](https://pypi.org/project/personal-understanding/)
