### PR TITLE
Add BulkPublish social media skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ gh skill publish                                 # 校验并发布技能
 -   [dontbesilent](https://github.com/dontbesilent2025/dbskill)： X 万粉大V 基于自己的推文制作的内容创作框架
 -   [seekjourney](https://github.com/geekjourneyx/md2wechat-skill/)：从写作到发布的 AI 辅助公众号写作
 -   [cangjie-skill](https://github.com/kangarooking/cangjie-skill)：把书、视频和播客蒸馏为可执行的 Agent Skills
+-   [BulkPublish Social Media Skills](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills)：面向 AI Agent 的社交媒体内容规划、改写、审核、排程与发布技能集合
 
 ### 产品使用
 


### PR DESCRIPTION
Adds BulkPublish’s social media content skills collection to 内容创作. The linked collection covers AI-agent content planning, adaptation, review, scheduling, and publishing, with the BulkPublish API and MCP documentation available from the canonical repository.\n\nSkills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills\nAPI: https://github.com/azeemkafridi/bulkpublish-api\nMCP docs: https://app.bulkpublish.com/docs\n\nDisclosure: I am affiliated with BulkPublish and am submitting this entry for consideration.