### PR TITLE
收录高信号治理、安全与 Skill 集合

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ my-plugin/
 - [flutter/agent-plugins](https://github.com/flutter/agent-plugins)：Flutter 团队维护的跨 Claude Code、Codex 与 Cursor 的开发能力包。
 - [awslabs/agent-plugins](https://github.com/awslabs/agent-plugins)：面向 AWS 架构、部署和运维任务的 Agent Plugins。
 
+### 规范、治理与安全工具
+
+- [Tencent/AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard)：腾讯朱雀实验室维护的 AI 红队与基础设施安全平台；其中的 `aig-agent-redteam` Skill 可执行授权动态测试，涉及网络探测、命令执行和目标交互，应只在明确授权及隔离边界内使用。
+- [AMAP-ML/SkillClaw](https://github.com/AMAP-ML/SkillClaw)：面向 Skill 演化、去重与跨端共享的基础设施；它可以代理模型请求、记录会话并自动改写 Skill，启用共享存储或自动演化前应审查隐私、凭据和写入边界。
+
 ## 组件生态
 
 组件可以单独使用，也可以进一步组合进标准 Plugin。下面只保留高质量发现入口；收录、Star 数和格式校验都不代表安全审计或跨客户端兼容认证。
@@ -130,6 +135,7 @@ my-plugin/
 - [sickn33/agentic-awesome-skills](https://github.com/sickn33/agentic-awesome-skills)：覆盖大规模 Skill 发现、选择、校验与规划的目录和本地工具链。
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)：面向多种 Agent 客户端的社区 Skill 汇总目录。
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills)：Agent Skills 教程、指南与目录索引。
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills)：面向研究、社交情报和业务工作流的跨客户端 Skill 集合；部分 Skill 可复用宿主工具，另一些会调用外部数据服务，使用前应核对凭据、数据传输和服务依赖。
 
 ### MCP Servers（标准核心组件）
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -121,6 +121,11 @@ The current public compatibility matrix lists VS Code, Cursor, GitHub Copilot, C
 - [flutter/agent-plugins](https://github.com/flutter/agent-plugins): Flutter-team capability packages for Claude Code, Codex, and Cursor workflows.
 - [awslabs/agent-plugins](https://github.com/awslabs/agent-plugins): Agent Plugins for AWS architecture, deployment, and operations tasks.
 
+### Specification, Governance, and Security Tooling
+
+- [Tencent/AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard): An AI red-teaming and infrastructure-security platform maintained by Tencent Zhuque Lab. Its `aig-agent-redteam` Skill can perform authorized dynamic tests involving network probes, command execution, and target interaction, so it should be used only with explicit authorization and isolated boundaries.
+- [AMAP-ML/SkillClaw](https://github.com/AMAP-ML/SkillClaw): Infrastructure for Skill evolution, deduplication, and cross-device sharing. It can proxy model requests, record sessions, and rewrite Skills automatically; review privacy, credential, and write boundaries before enabling shared storage or automatic evolution.
+
 ## Component Ecosystem
 
 Components can be used independently or assembled into a standard Plugin. The list below keeps only high-quality discovery points. Inclusion, Stars, and format validation are not security audits or cross-client compatibility certifications.
@@ -130,6 +135,7 @@ Components can be used independently or assembled into a standard Plugin. The li
 - [sickn33/agentic-awesome-skills](https://github.com/sickn33/agentic-awesome-skills): A catalog and local toolchain for large-scale Skill discovery, selection, validation, and planning.
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills): A community Skill directory spanning multiple Agent clients.
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills): Agent Skills tutorials, guides, and directory indexes.
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills): A cross-client Skill collection for research, social intelligence, and business workflows. Some Skills reuse host tools while others call external data services; review credentials, data transmission, and service dependencies before use.
 
 ### MCP Servers (Standard Core Component)
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -121,6 +121,11 @@ my-plugin/
 - [flutter/agent-plugins](https://github.com/flutter/agent-plugins)：Flutter チームが管理する Claude Code、Codex、Cursor 向け能力パッケージです。
 - [awslabs/agent-plugins](https://github.com/awslabs/agent-plugins)：AWS の設計、デプロイ、運用タスク向け Agent Plugins です。
 
+### 仕様・ガバナンス・セキュリティツール
+
+- [Tencent/AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard)：Tencent Zhuque Lab が管理する AI レッドチームおよびインフラセキュリティ基盤です。`aig-agent-redteam` Skill はネットワーク探査、コマンド実行、対象との対話を伴う認可済み動的テストを実行できるため、明示的な許可と隔離された境界の中でのみ使用してください。
+- [AMAP-ML/SkillClaw](https://github.com/AMAP-ML/SkillClaw)：Skill の進化、重複排除、端末間共有のための基盤です。モデル要求のプロキシ、セッション記録、Skill の自動書き換えを行えるため、共有ストレージや自動進化を有効にする前に、プライバシー、認証情報、書き込み境界を確認してください。
+
 ## Component エコシステム
 
 Component は単独でも利用でき、標準 Plugin に組み込むこともできます。以下は高品質な発見入口だけを残しています。掲載、Star 数、形式検証は、セキュリティ監査やクライアント間互換性の認証を意味しません。
@@ -130,6 +135,7 @@ Component は単独でも利用でき、標準 Plugin に組み込むことも�
 - [sickn33/agentic-awesome-skills](https://github.com/sickn33/agentic-awesome-skills)：大規模な Skill の発見、選択、検証、計画を支援するカタログとローカルツールチェーンです。
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)：複数の Agent クライアントを対象とするコミュニティ Skill ディレクトリです。
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills)：Agent Skills のチュートリアル、ガイド、ディレクトリです。
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills)：調査、ソーシャルインテリジェンス、業務ワークフロー向けのクライアント横断 Skill コレクションです。宿主ツールを再利用する Skill もあれば外部データサービスを呼び出すものもあるため、利用前に認証情報、データ送信、サービス依存関係を確認してください。
 
 ### MCP Servers（標準コア Component）
 


### PR DESCRIPTION
## 变更

- 收录 Tencent AI-Infra-Guard，并明确动态红队测试的授权与执行风险
- 收录 SkillClaw，并明确模型代理、会话记录、共享存储和自动写入风险
- 收录 SandBase Skills 集合，并区分宿主工具复用与外部数据服务依赖
- 同步中文、英文、日文 README

## 验证

- 三个上游仓库当前可访问、未归档且持续维护
- 许可证分别为 Apache-2.0、MIT、Apache-2.0
- `git diff --check`

关联：#144、#41、#137、#130