### PR TITLE
Add claude-real-video as a standalone Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ my-plugin/
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)：面向多种 Agent 客户端的社区 Skill 汇总目录。
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills)：Agent Skills 教程、指南与目录索引。
 - [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills)：面向研究、社交情报和业务工作流的跨客户端 Skill 集合；部分 Skill 可复用宿主工具，另一些会调用外部数据服务，使用前应核对凭据、数据传输和服务依赖。
+- [HUANGCHIHHUNGLeo/claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video)：独立 Skill（`skills/claude-real-video/SKILL.md`），本地场景感知抽帧＋时间戳转录，让 Claude 或其他 LLM 处理视频而非只读字幕；MIT，无 Agent Plugins v1 根清单，不作可移植 Plugin 声明。
 
 ### MCP Servers（标准核心组件）
 


### PR DESCRIPTION
## What this changes

Adds one entry to the "Skills（标准核心组件）" section: HUANGCHIHHUNGLeo/claude-real-video, a standalone component (Skill), not a portable Agent Plugins v1 package.

## Classification

- Entry type: Skill (standalone component)
- Canonical source: https://github.com/HUANGCHIHHUNGLeo/claude-real-video
- Format and manifest path: `skills/claude-real-video/SKILL.md`; repo also ships a Claude Code host-native plugin at `plugins/claude-real-video/.claude-plugin/plugin.json` (no `$schema`, so it is host-native, not an Agent Plugins v1 claim)
- Portability claim: standalone component (SKILL.md); no root Agent Plugins v1 `plugin.json`
- Supported clients: Claude Code (native plugin + skill), any LLM/agent via the `crv` CLI directly (skill format is Claude-oriented, the CLI itself is client-agnostic)
- Portable core components (Skills / MCP): Skill only, no MCP server
- Client-specific capabilities: Claude Code plugin manifest (`.claude-plugin/plugin.json`), no Agents/Commands/Hooks
- Installation or usage path: `pip install "claude-real-video[whisper]"` then `crv "<url-or-path>" -o crv-out --grid`
- License and source availability: MIT, fully open source
- Last verified (`YYYY-MM-DD`): 2026-09-03 — installed via pip, ran `crv` against a local file, confirmed MANIFEST.txt + frames output
- Risk surfaces: runs 100% locally (ffmpeg, whisper); no network calls, no credentials, no external reads/writes beyond the local filesystem it's pointed at

## Checklist

- [x] The terminology matches `CONTRIBUTING.md`.
- [x] A portable Agent Plugins v1 claim is backed by a root `plugin.json` declaring the canonical `$schema`. — N/A, this entry does not claim v1 portability.
- [x] Client-specific formats and capabilities are labeled separately from the portable core.
- [x] Compatibility, installation, and execution claims are supported by the linked source or a documented test.
- [x] The description does not treat Stars, schema validity, or Marketplace inclusion as a security guarantee.
- [ ] Shared structural changes are synchronized across Chinese, English, and Japanese READMEs. — single resource addition to zh README only, per CONTRIBUTING.md maintainers may help sync translations.
- [x] I did not reformat or reorder unrelated content.
