### PR TITLE
Add Market Brief to curated skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ gh skill publish                                 # 校验并发布技能
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：使用 YC 的视角提供各种创业建议
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：强化市场营销的能力
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)： 提升科研工作者的技能
+-   [market-brief](https://github.com/beepboop2025/market-brief/tree/v0.1.0/skills/market-brief)：读取公开资金市场与流动性数据，保留来源日期、缺失状态和披露限制；不执行交易
 
 
 ## 安全审查

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -273,6 +273,7 @@ gh skill publish                                 # Validate and publish a Skill
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours): Provide startup advice from a YC perspective
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills): Enhance marketing capabilities
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills): Improve skills for researchers
+-   [market-brief](https://github.com/beepboop2025/market-brief/tree/v0.1.0/skills/market-brief): Summarize public funding and liquidity evidence with source dates and explicit missing or withheld data; no trade execution
 
 ## Security Audit
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -273,6 +273,7 @@ gh skill publish                                 # Skill を検証して公開
 -   [office-hours](https://github.com/garrytan/gstack/tree/main/office-hours)：YC の視点から様々な起業アドバイスを提供
 -   [marketingskills](https://github.com/coreyhaines31/marketingskills)：マーケティング能力を強化
 -   [scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)：研究者のスキルを向上
+-   [market-brief](https://github.com/beepboop2025/market-brief/tree/v0.1.0/skills/market-brief)：公開の短期金融市場・流動性データを要約し、出典の日時と欠落・非公開の状態を保持。取引は実行しない
 
 ## セキュリティ監査
 


### PR DESCRIPTION
Adds the Market Brief skill to the existing Other Types category, with matching descriptions in the Chinese, English, and Japanese READMEs. The link pins v0.1.0.

Market Brief is an MIT-licensed research skill from Liquidity Lab. Its Python helper reads three fixed public HTTPS sources and compares an explicitly saved brief while keeping source dates and missing or withheld data visible. It does not require a broker connection or API key.

Example: "Give me a funding and liquidity brief with source dates and gaps; compare with my saved brief if supplied."

This adds one resource to the existing category and preserves the surrounding ordering. The skill's documented network and local-file behavior is visible at the linked source.

Validation: the pinned skill link returns HTTP 200; all three descriptions retain the same coverage, evidence-gap, and no-execution boundaries; `git diff --check` passes. Existing resources and PRs were checked for duplicates.

Credit: Liquidity Lab / @beepboop2025. I maintain the submitted project.
