### PR TITLE
新增 orca-replay 到编程开发

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ gh skill publish                                 # 校验并发布技能
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad)：面向 CAD、CAE 与 CAM 的工程技能库
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill)：跨平台桌面应用的原生体验设计指南
+-   [orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay)：从录像回答「上一次运行为什么这么做」，可离线重放或分叉到其他模型
 
 
 ### 内容创作


### PR DESCRIPTION
在 **精选技能 → 编程开发** 下新增 `orca-replay`。

**这个技能解决什么。** agent 跑完一轮之后，问它「你刚才为什么删掉那个文件」，它只能凭上下文重构，而上下文里往往已经没有这些信息了——跑过哪些命令、退出码是多少、每一轮改了哪些文件，都不在。这个技能让 agent 改为去读**录像**：什么是记录里确实存在的、什么是它自己推断的，两者分开说。

背后的 OrcaReplay 在进程和 socket 这一层捕获，所以模型请求、shell 退出码、每轮文件变更、MCP 调用落在同一条时间线上；之后可以断网离线逐字节重放，或从任一检查点分叉到另一个模型。

**关于安全审查那一节。** 技能里明确写了三处需要先征得用户同意再动作：全局安装、`orca_compare`（会把录制的上下文上传给第三方模型厂商、真实花钱、并且分叉出来的是活的 agent，它的 shell 命令会真的执行）、以及重放可能重复原运行在工作区之外产生的副作用。这些不是我事后补的说明——同一份 SKILL.md 经 `sickn33/agentic-awesome-skills` 十四轮对抗性评审后合并，也已发布到 ClawHub 并通过其安全扫描，扫描结论专门点出「replay 与数据共享的风险在指令中已被明确指出」。

Apache-2.0。依赖 `orcareplay` npm 包及其 MCP server，这一点写在技能自己的 frontmatter 里，不会让人用到一半才发现。

一句实话：项目 2026-08-29 才建库，150 star，还很新。
