### PR TITLE
新增 ctx-optimize（编程开发）

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ gh skill publish                                 # 校验并发布技能
 -   [archify](https://github.com/tt-a1i/archify)：生成可验证、可导出的架构图与流程图
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad)：面向 CAD、CAE 与 CAM 的工程技能库
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill)：跨平台桌面应用的原生体验设计指南
+-   [ctx-optimize](https://github.com/muthuishere/ctx-optimize)：把代码库索引为本地知识图谱，回答调用关系与改动影响
 
 
 ### 内容创作

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -247,6 +247,7 @@ gh skill publish                                 # Validate and publish a Skill
 -   [archify](https://github.com/tt-a1i/archify): Verifiable, exportable architecture and workflow diagrams
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad): CAD, CAE, and CAM agent skills
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill): Native-feeling cross-platform desktop app guidance
+-   [ctx-optimize](https://github.com/muthuishere/ctx-optimize): Local code knowledge graph answering call relationships and change impact
 
 ### Content Creation
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -247,6 +247,7 @@ gh skill publish                                 # Skill を検証して公開
 -   [archify](https://github.com/tt-a1i/archify)：検証・エクスポート可能なアーキテクチャ図とフロー図
 -   [text-to-cad](https://github.com/earthtojake/text-to-cad)：CAD、CAE、CAM 向け Agent Skills
 -   [native-feel-skill](https://github.com/yetone/native-feel-skill)：クロスプラットフォーム・デスクトップアプリのネイティブ体験設計
+-   [ctx-optimize](https://github.com/muthuishere/ctx-optimize)：コードベースをローカルの知識グラフに索引化し、呼び出し関係と変更影響に回答
 
 ### コンテンツ制作
 


### PR DESCRIPTION
## 新增条目

**名称**：ctx-optimize
**链接**：https://github.com/muthuishere/ctx-optimize
**分类**：精选技能 → 编程开发
**许可证**：MIT ｜ **语言**：Go ｜ **版本**：v0.15.0

**利益披露**：我是该项目的作者。以下均为可核验的事实描述，没有营销措辞。

### 这是什么

一个面向编码 Agent 的确定性代码知识图谱。单个静态 Go 二进制文件把仓库（以及可选的数据库、对象存储、消息队列和 API）索引成本地图谱，Agent 通过一次调用就能回答「谁调用了它」「改动它会影响什么」，不必再走 grep + 逐个读文件的链路。

不含 LLM 调用、不含 embedding、不含数据库、不含 MCP，也不在本地留存任何凭据。

### 它确实是一个 Skill

仓库内置 Agent Skill：`internal/skills/bundled/ctx-optimize/SKILL.md`，通过 `ctx-optimize install --skills` 安装（同时分发到 Claude Code 与 Codex）。

Skill 提供的动词：`query`、`card <symbol>`、`change-plan <symbol>`、`affected <symbol>`、`path <a> <b>`、`boundaries`、`verify`。

安装：`npm install -g @muthuishere/ctx-optimize`

### 说明

项目约 2 个月，目前 0 star，没有任何采用量可言 —— 我不以社区认可度作为收录理由，只以「它是一个可直接安装、有明确 SKILL.md 的开源 Skill」提交，是否符合本列表「少而精」的定位由维护者判断，不合适请直接关闭，完全理解。

### 检查清单

- [x] 链接有效，仓库公开可访问
- [x] 同步更新了 `README.md`、`docs/README_EN.md`、`docs/README_JA.md`
- [x] 放入现有分类（编程开发），未新增 section
- [x] 追加在分类末尾，未改动任何既有条目的顺序或格式
- [x] 差异仅 3 行（每个语言文件 1 行）
- [x] 仓库包含 SKILL.md
